### PR TITLE
use $XDG_DATA_HOME for storing tasks

### DIFF
--- a/qo.sh
+++ b/qo.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-tasks_store="$HOME/.tasks.qo.txt"
+qo_home="${XDG_DATA_HOME:-$HOME/.local/share}/qo"
+mkdir -p $qo_home
+
+tasks_store="$qo_home/tasks.txt"
 
 [ ! -f $tasks_store ] && touch $tasks_store
 


### PR DESCRIPTION
regarding https://reddit.com/r/commandline/comments/q125yq/comment/hfci02n

this change makes `qo` store tasks in `$XDG_CONFIG_HOME/qo/tasks.txt`, falls back to `~/.local/share/qo/tasks.txt` if `$XDG_CONFIG_HOME` isn't present, as opposed to `$HOME/.tasks.qo.txt`. in addition, it creates `$XDG_CONFIG_HOME/qo` if it doesn't already exist.